### PR TITLE
Add carousel feed with product slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,9 @@ pip install -r requirements.txt
 python -m ponsiv.main
 ```
 
-The app loads seed data from `assets/seed/*.json` on startup. The window is fixed at **360×640** and uses a dark theme.
+Product information is loaded automatically from the ``assets`` directory. Each
+product has a JSON description in ``assets/informacion`` and a corresponding
+image in ``assets/prendas``. Brand logos live in ``assets/logos``. Adding a new
+product only requires placing its JSON and image files in these folders.
+
+The window is fixed at **360×640** and uses a dark theme.

--- a/ponsiv/components/product_slide.py
+++ b/ponsiv/components/product_slide.py
@@ -1,24 +1,135 @@
+from kivy.core.window import Window
+from kivy.graphics import Color, Ellipse, RoundedRectangle
+from kivy.metrics import dp
 from kivy.properties import ObjectProperty
+from kivy.uix.floatlayout import FloatLayout
+from kivy.uix.image import Image
 from kivymd.uix.card import MDCard
-from kivymd.uix.image import FitImage
+from kivymd.uix.fitimage import FitImage
+from kivymd.uix.button import MDIconButton
 from kivymd.uix.label import MDLabel
 
 
-class ProductSlide(MDCard):
-    """Simple card displaying a product image and name."""
+class ProductSlide(FloatLayout):
+    """Slide showing a single product with image and overlaid info."""
 
     product = ObjectProperty()
 
     def __init__(self, product, **kwargs):
         super().__init__(**kwargs)
         self.product = product
-        self.orientation = "vertical"
-        self.radius = [12]
-        self.elevation = 2
-        self.padding = 4
 
-        if product.images:
-            self.add_widget(FitImage(source=product.images[0]))
-        self.add_widget(
-            MDLabel(text=f"{product.title} - ${product.price:.2f}", halign="center")
+        available_height = Window.height - dp(15)
+
+        img_card = MDCard(
+            size_hint=(0.97, None),
+            height=available_height,
+            pos_hint={"center_x": 0.5, "y": 0.01},
+            radius=[dp(20)],
+            elevation=0,
         )
+        if product.images:
+            img_card.add_widget(FitImage(source=product.images[0]))
+        self.add_widget(img_card)
+
+        info_card = MDCard(
+            size_hint=(0.9, None),
+            height=dp(120),
+            pos_hint={"center_x": 0.5, "y": 0.06},
+            md_bg_color=(0, 0, 0, 0.6),
+            radius=[dp(16)],
+            elevation=0,
+        )
+
+        fl = FloatLayout(size_hint=(1, 1))
+
+        if product.logo:
+            with fl.canvas.before:
+                Color(1, 1, 1, 1)
+                Ellipse(
+                    pos=(dp(27), info_card.height - dp(40) + dp(13)),
+                    size=(dp(48), dp(48)),
+                )
+            fl.add_widget(
+                Image(
+                    source=product.logo,
+                    size_hint=(None, None),
+                    size=(dp(40), dp(40)),
+                    pos=(dp(32), info_card.height - dp(40) + dp(17)),
+                )
+            )
+
+        fl.add_widget(
+            MDLabel(
+                text=product.title,
+                font_size="16sp",
+                bold=True,
+                theme_text_color="Custom",
+                text_color=(1, 1, 1, 1),
+                size_hint=(None, None),
+                size=(dp(250), dp(20)),
+                pos=(dp(80), info_card.height - dp(40) + dp(40)),
+            )
+        )
+
+        fl.add_widget(
+            MDLabel(
+                text=product.brand,
+                font_size="14sp",
+                theme_text_color="Custom",
+                text_color=(0.8, 0.8, 0.8, 1),
+                size_hint=(None, None),
+                size=(dp(100), dp(20)),
+                pos=(dp(80), info_card.height - dp(40) + dp(20)),
+            )
+        )
+
+        fl.add_widget(
+            MDLabel(
+                text=", ".join(product.sizes),
+                font_size="12sp",
+                theme_text_color="Custom",
+                text_color=(0.8, 0.8, 0.8, 1),
+                size_hint=(None, None),
+                size=(dp(200), dp(18)),
+                pos=(dp(230), info_card.height - dp(40) - dp(30)),
+            )
+        )
+
+        fl.add_widget(
+            MDLabel(
+                text=f"{product.price:.2f} €",
+                font_size="14sp",
+                bold=True,
+                theme_text_color="Custom",
+                text_color=(1, 1, 1, 1),
+                size_hint=(None, None),
+                size=(dp(100), dp(20)),
+                pos=(dp(29), info_card.height - dp(40) - dp(30)),
+            )
+        )
+
+        info_card.add_widget(fl)
+        self.add_widget(info_card)
+
+        pw, ph = 0.18, 0.36
+        px, py = 1 - pw - 0.07, 0.5 - ph / 2
+        with self.canvas.before:
+            Color(0, 0, 0, 0.4)
+            RoundedRectangle(
+                pos=(Window.width * px, Window.height * py),
+                size=(Window.width * pw, Window.height * ph),
+                radius=[dp(30)],
+            )
+        icons = ["heart-outline", "bookmark-outline", "share", "tshirt-crew"]
+        for i, ic in enumerate(icons):
+            btn = MDIconButton(
+                icon=ic,
+                icon_size="20sp",
+                theme_text_color="Custom",
+                text_color=(1, 1, 1, 1),
+                size_hint=(None, None),
+                size=("30sp", "30sp"),
+                pos_hint={"x": px + (pw - 0.05) / 2, "y": py + ph - 0.15 - i * 0.06},
+            )
+            self.add_widget(btn)

--- a/ponsiv/models.py
+++ b/ponsiv/models.py
@@ -8,12 +8,9 @@ class Product:
     brand: str
     title: str
     price: float
-    images: List[str]
     sizes: List[str]
-    color: str
-    category: str
-    stock: int
-    checkout_url: Optional[str] = None
+    images: List[str]
+    logo: Optional[str] = None
 
 
 @dataclass

--- a/ponsiv/screens/feed.py
+++ b/ponsiv/screens/feed.py
@@ -1,8 +1,17 @@
+from kivy.uix.carousel import Carousel
 from kivymd.uix.screen import MDScreen
-from kivymd.uix.label import MDLabel
+
+from ..components.product_slide import ProductSlide
+from ..store import store
 
 
 class FeedScreen(MDScreen):
+    """Screen displaying products in a vertical carousel."""
+
     def on_pre_enter(self, *args):
-        if not self.children:
-            self.add_widget(MDLabel(text="Feed", halign="center"))
+        if self.children:
+            return
+        carousel = Carousel(direction="bottom", loop=False)
+        for product in store.products.values():
+            carousel.add_widget(ProductSlide(product))
+        self.add_widget(carousel)


### PR DESCRIPTION
## Summary
- Implement rich `ProductSlide` component with image, brand logo, and overlayed details
- Replace feed screen with vertical carousel of product slides
- Fix KivyMD icon button import for compatibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from ponsiv.store import store
print('products:', len(store.products))
print('example:', next(iter(store.products)))
PY`
- ⚠️ `python - <<'PY'
from ponsiv.components.product_slide import ProductSlide
print('ProductSlide loaded')
PY` *(fails: Couldn't connect to X server)*

------
https://chatgpt.com/codex/tasks/task_e_68adea21f3c48328b6d8016021dce474