### PR TITLE
Add SQLite-backed authentication and profile features

### DIFF
--- a/ponsiv/components/product_slide.py
+++ b/ponsiv/components/product_slide.py
@@ -6,6 +6,8 @@ from kivymd.uix.fitimage import FitImage
 from kivymd.uix.button import MDIconButton
 from kivymd.uix.label import MDLabel
 
+from ..store import store
+
 
 class ProductSlide(FloatLayout):
     """
@@ -88,11 +90,23 @@ class ProductSlide(FloatLayout):
 
         # ── Columna de iconos flotantes (derecha) estilo "chips" blancos ────────
         # Orden como en la imagen: corazón, paper-plane (share), comment, t-shirt
-        icons = ["heart-outline", "send-outline", "comment-outline", "tshirt-crew"]
         base_y = 0.60
         step = 0.10
-        for i, ic in enumerate(icons):
-            self.add_widget(self._round_icon(ic, pos_hint={"center_x": 0.93, "center_y": base_y - i * step}))
+
+        # Heart button with like toggle
+        self.heart_btn = self._round_icon("heart-outline", pos_hint={"center_x": 0.93, "center_y": base_y})
+        self.heart_btn.bind(on_release=self.toggle_like)
+        if store.current_user_id and store.is_product_liked(store.current_user_id, self.product.id):
+            self.heart_btn.icon = "heart"
+        self.add_widget(self.heart_btn)
+
+        icons = ["send-outline", "comment-outline", "tshirt-crew"]
+        for i, ic in enumerate(icons, start=1):
+            self.add_widget(
+                self._round_icon(
+                    ic, pos_hint={"center_x": 0.93, "center_y": base_y - i * step}
+                )
+            )
 
     def _round_icon(self, icon_name: str, pos_hint: dict) -> MDIconButton:
         """
@@ -111,3 +125,9 @@ class ProductSlide(FloatLayout):
         btn.size = (dp(40), dp(40))
         btn.radius = [dp(20)]
         return btn
+
+    def toggle_like(self, *_):
+        if not store.current_user_id:
+            return
+        liked = store.toggle_like(store.current_user_id, self.product.id)
+        self.heart_btn.icon = "heart" if liked else "heart-outline"

--- a/ponsiv/models.py
+++ b/ponsiv/models.py
@@ -30,16 +30,14 @@ class Look:
 
 @dataclass
 class User:
-    id: str
+    """Basic user profile stored in the local SQLite database."""
+
+    id: int
+    email: str
+    password_hash: str
     name: str
     handle: str
-    avatar: str
-    following: int
-    followers: int
-    outfitsCount: int
-    wardrobe: List[str]
-    likes: List[str]
-    orders: List[str]
+    avatar_path: Optional[str] = None
 
 
 @dataclass

--- a/ponsiv/screens/login.py
+++ b/ponsiv/screens/login.py
@@ -1,8 +1,41 @@
 from kivymd.uix.screen import MDScreen
+from kivymd.uix.boxlayout import MDBoxLayout
+from kivymd.uix.textfield import MDTextField
+from kivymd.uix.button import MDFlatButton
 from kivymd.uix.label import MDLabel
+
+from ..store import store
 
 
 class LoginScreen(MDScreen):
+    """Screen that allows the user to login or create an account."""
+
     def on_pre_enter(self, *args):
-        if not self.children:
-            self.add_widget(MDLabel(text="Login", halign="center"))
+        self.clear_widgets()
+        layout = MDBoxLayout(orientation="vertical", padding=20, spacing=20)
+        self.email_field = MDTextField(hint_text="Email")
+        self.password_field = MDTextField(hint_text="Password", password=True)
+        btn = MDFlatButton(text="Login / Signup", on_release=self.handle_auth)
+        self.message = MDLabel(text="", halign="center")
+        layout.add_widget(self.email_field)
+        layout.add_widget(self.password_field)
+        layout.add_widget(btn)
+        layout.add_widget(self.message)
+        self.add_widget(layout)
+
+    def handle_auth(self, *_):
+        email = self.email_field.text.strip()
+        password = self.password_field.text
+        if not email or not password:
+            self.message.text = "Please enter email and password"
+            return
+
+        user_id = store.authenticate_user(email, password)
+        if user_id is None:
+            if store.get_user_by_email(email) is not None:
+                self.message.text = "Incorrect password"
+                return
+            user_id = store.create_user(email, password)
+
+        store.current_user_id = user_id
+        self.manager.current = "feed"

--- a/ponsiv/screens/profile.py
+++ b/ponsiv/screens/profile.py
@@ -1,13 +1,54 @@
 from kivymd.uix.screen import MDScreen
-from kivymd.uix.label import MDLabel
+from kivymd.uix.boxlayout import MDBoxLayout
+from kivymd.uix.label import MDLabel, MDIcon
+from kivymd.uix.button import MDFlatButton
+from kivymd.uix.fitimage import FitImage
+from kivymd.uix.dialog import MDDialog
+from kivy.uix.filechooser import FileChooserIconView
+
 from ..store import store
 
 
 class ProfileScreen(MDScreen):
-    user_id = 1
+    dialog = None
 
     def on_pre_enter(self, *args):
-        user = store.users.get(self.user_id)
-        name = user.name if user else "Guest"
         self.clear_widgets()
-        self.add_widget(MDLabel(text=f"Profile: {name}", halign="center"))
+        layout = MDBoxLayout(orientation="vertical", padding=20, spacing=20)
+        user = store.get_user(store.current_user_id) if store.current_user_id else None
+
+        if user and user.avatar_path:
+            self.avatar_widget = FitImage(source=user.avatar_path, size_hint=(None, None), size=(150, 150))
+        else:
+            self.avatar_widget = MDIcon(icon="account-circle", halign="center", font_size="64sp")
+        layout.add_widget(self.avatar_widget)
+        layout.add_widget(MDFlatButton(text="Change Photo", on_release=self.open_file_chooser))
+
+        name = user.name if user else "Guest"
+        layout.add_widget(MDLabel(text=f"{name}", halign="center"))
+
+        liked_ids = store.get_liked_product_ids(store.current_user_id) if store.current_user_id else []
+        for pid in liked_ids:
+            product = store.products.get(pid)
+            if product:
+                layout.add_widget(MDLabel(text=product.title, halign="center"))
+
+        self.add_widget(layout)
+
+    def open_file_chooser(self, *_):
+        chooser = FileChooserIconView()
+        self.dialog = MDDialog(
+            title="Select Avatar",
+            type="custom",
+            content_cls=chooser,
+            buttons=[MDFlatButton(text="Close", on_release=lambda *x: self.dialog.dismiss())],
+        )
+        chooser.bind(on_selection=self._file_selected)
+        self.dialog.open()
+
+    def _file_selected(self, chooser, selection):
+        if selection:
+            path = selection[0]
+            store.update_user_avatar(store.current_user_id, path)
+            self.dialog.dismiss()
+            self.on_pre_enter()


### PR DESCRIPTION
## Summary
- implement email/password login and signup storing users in SQLite
- allow avatar upload and show liked products in profile
- add product like toggling with persistence per user

## Testing
- `python -m py_compile ponsiv/models.py ponsiv/store.py ponsiv/screens/login.py ponsiv/screens/profile.py ponsiv/components/product_slide.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae07b382b083288d14a8d348d109d0