### PR TITLE
Add category-aware explore screen with summer banner

### DIFF
--- a/assets/informacion/BERMUDA_PINZAS_CINTURON.json
+++ b/assets/informacion/BERMUDA_PINZAS_CINTURON.json
@@ -8,5 +8,6 @@
         "M",
         "L",
         "XL"
-    ]
+    ],
+    "categoria": "Bermudas"
 }

--- a/assets/informacion/CAMISA_BASICA_SATINADA.json
+++ b/assets/informacion/CAMISA_BASICA_SATINADA.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Camisas"
 }

--- a/assets/informacion/CAMISA_ENCAJE_TRIANGULO_ANTRACITA.json
+++ b/assets/informacion/CAMISA_ENCAJE_TRIANGULO_ANTRACITA.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Camisas"
 }

--- a/assets/informacion/CAMISA_MANGA_ANCHA.json
+++ b/assets/informacion/CAMISA_MANGA_ANCHA.json
@@ -7,5 +7,6 @@
         "M",
         "L",
         "XL"
-    ]
+    ],
+    "categoria": "Camisas"
 }

--- a/assets/informacion/CAMISA_ROMANTICA_ANTRACITA.json
+++ b/assets/informacion/CAMISA_ROMANTICA_ANTRACITA.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Camisas"
 }

--- a/assets/informacion/CAMISA_ROMANTICA_BLANCA.json
+++ b/assets/informacion/CAMISA_ROMANTICA_BLANCA.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Camisas"
 }

--- a/assets/informacion/CAMISA_VOLANTES.json
+++ b/assets/informacion/CAMISA_VOLANTES.json
@@ -6,5 +6,6 @@
         "XS",
         "S",
         "M"
-    ]
+    ],
+    "categoria": "Camisas"
 }

--- a/assets/informacion/CAMISETA_ABERTURAS_BLANCA.json
+++ b/assets/informacion/CAMISETA_ABERTURAS_BLANCA.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Camisetas"
 }

--- a/assets/informacion/CAMISETA_CRUZADA_PLATEADA.json
+++ b/assets/informacion/CAMISETA_CRUZADA_PLATEADA.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Camisetas"
 }

--- a/assets/informacion/CAMISETA_TIRA_ESPALDA_MORA.json
+++ b/assets/informacion/CAMISETA_TIRA_ESPALDA_MORA.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Camisetas"
 }

--- a/assets/informacion/CHAQUETA_DENIM_LENTEJUELAS.json
+++ b/assets/informacion/CHAQUETA_DENIM_LENTEJUELAS.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Chaquetas"
 }

--- a/assets/informacion/CHAQUETA_MANGA_REMANGADA.json
+++ b/assets/informacion/CHAQUETA_MANGA_REMANGADA.json
@@ -6,5 +6,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Chaquetas"
 }

--- a/assets/informacion/CHAQUETA_SAFARI_CON_LINO.json
+++ b/assets/informacion/CHAQUETA_SAFARI_CON_LINO.json
@@ -8,5 +8,6 @@
         "M",
         "L",
         "XL"
-    ]
+    ],
+    "categoria": "Chaquetas"
 }

--- a/assets/informacion/PANTALON_TEXTURA_DORADO.json
+++ b/assets/informacion/PANTALON_TEXTURA_DORADO.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Pantalones"
 }

--- a/assets/informacion/SOBRECAMISA_SAFARI.json
+++ b/assets/informacion/SOBRECAMISA_SAFARI.json
@@ -6,5 +6,6 @@
         "M",
         "L",
         "XL"
-    ]
+    ],
+    "categoria": "Chaquetas"
 }

--- a/assets/informacion/TOP_CHALECO_PUNTO_LISO.json
+++ b/assets/informacion/TOP_CHALECO_PUNTO_LISO.json
@@ -6,5 +6,6 @@
         "XS",
         "S",
         "M"
-    ]
+    ],
+    "categoria": "Tops"
 }

--- a/assets/informacion/TOP_GOMAS_LILA.json
+++ b/assets/informacion/TOP_GOMAS_LILA.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Tops"
 }

--- a/assets/informacion/TOP_PUNTO_MANGA_CORTA.json
+++ b/assets/informacion/TOP_PUNTO_MANGA_CORTA.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Tops"
 }

--- a/assets/informacion/VESTIDO_GOMAS_VOLANTE_NARANJA.json
+++ b/assets/informacion/VESTIDO_GOMAS_VOLANTE_NARANJA.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Vestidos"
 }

--- a/assets/informacion/VESTIDO_MIDI_CUT.json
+++ b/assets/informacion/VESTIDO_MIDI_CUT.json
@@ -7,5 +7,6 @@
         "S",
         "M",
         "L"
-    ]
+    ],
+    "categoria": "Vestidos"
 }

--- a/ponsiv/models.py
+++ b/ponsiv/models.py
@@ -11,6 +11,7 @@ class Product:
     sizes: List[str]
     images: List[str]
     logo: Optional[str] = None
+    category: Optional[str] = None
 
 
 @dataclass
@@ -51,3 +52,4 @@ class Order:
     size: str
     status: str
     date: str
+

--- a/ponsiv/store.py
+++ b/ponsiv/store.py
@@ -203,6 +203,7 @@ class PonsivStore:
             title = data.get("nombre", pid)
             price = data.get("precio", 0.0)
             sizes = data.get("tallas", [])
+            category = data.get("categoria") or None
 
             image_file = None
             for ext in (".jpg", ".png"):
@@ -227,8 +228,16 @@ class PonsivStore:
                 sizes=sizes,
                 images=images,
                 logo=str(logo_file) if logo_file else None,
+                category=category,
             )
             self.products[product.id] = product
+
+    def get_categories(self) -> list[str]:
+        return sorted({p.category for p in self.products.values() if p.category})
+
+    def get_products_by_category(self, category: str) -> list[Product]:
+        c = (category or "").lower()
+        return [p for p in self.products.values() if (p.category or "").lower() == c]
 
     # Cart management -----------------------------------------------------
     def add_to_cart(self, product_id: str) -> None:
@@ -256,3 +265,4 @@ class PonsivStore:
 
 store = PonsivStore()
 store.load_seed()
+


### PR DESCRIPTION
## Summary
- extend product model to include `categoria`
- load categories from JSON and expose category helpers
- redesign explore screen with clickable summer banner and category cards with random product images
- annotate all product JSONs with `categoria`

## Testing
- `python -m py_compile ponsiv/models.py ponsiv/store.py ponsiv/screens/explore.py`
- `python - <<'PY'
import json,glob,sys
for path in glob.glob('assets/informacion/*.json'):
    with open(path,'r',encoding='utf-8') as f:
        try:
            json.load(f)
        except Exception as e:
            print('Error', path, e)
            sys.exit(1)
print('OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b2f680c9588328864c71db05ef9a21